### PR TITLE
Fix /admin path with hash redirect

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,6 +8,15 @@
   </head>
   <body>
     <div id="root"></div>
+    <script>
+      (function() {
+        var path = location.pathname;
+        if (path.startsWith('/admin') && !location.hash.startsWith('#/admin')) {
+          var rest = path.slice('/admin'.length);
+          location.replace('/#/admin' + rest + location.search + location.hash);
+        }
+      })();
+    </script>
     <script type="module" src="/src/main.jsx"></script>
   </body>
 </html>

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -237,6 +237,7 @@ function App() {
         <Route path="/smartlinks/:artistSlug/:trackSlug" element={<SmartLinkPage />} />
         <Route path="/admin/login" element={<AdminLogin />} />
         <Route path="/admin" element={<ProtectedRoute><AdminLayout /></ProtectedRoute>}>
+          <Route index element={<Navigate to="dashboard" replace />} />
           <Route path="dashboard" element={<AdminPanel />} />
           <Route path="artists" element={<Outlet />}>
             <Route index element={<ArtistListPage />} />
@@ -254,7 +255,7 @@ function App() {
           <Route path="reviews" element={<ReviewManager />} />
           <Route path="stats" element={<CampaignStatsShowcase />} />
         </Route>
-        <Route path="/admin" element={<Navigate to="/admin/dashboard" replace />} />
+        
         <Route path="*" element={<Navigate to="/" replace />} />
       </Routes>
     </Router>


### PR DESCRIPTION
## Summary
- redirect direct `/admin` requests to `/#/admin`

## Testing
- `npm run lint` *(fails to find `@eslint/js`)*

------
https://chatgpt.com/codex/tasks/task_e_6840d65bb39c83279ca228165bbfab8a